### PR TITLE
Add support for writing certificate signing requests

### DIFF
--- a/tests/openssl.rs
+++ b/tests/openssl.rs
@@ -2,7 +2,8 @@ extern crate openssl;
 extern crate rcgen;
 
 use rcgen::{Certificate, CertificateParams, DnType};
-use openssl::x509::{X509, X509StoreContext};
+use openssl::pkey::PKey;
+use openssl::x509::{X509, X509Req, X509StoreContext};
 use openssl::x509::store::{X509StoreBuilder, X509Store};
 use openssl::stack::Stack;
 
@@ -30,4 +31,16 @@ fn test_openssl() {
 		ctx.verify_cert().unwrap();
 		Ok(())
 	}).unwrap();
+}
+
+#[test]
+fn test_request() {
+	let params = CertificateParams::new(vec!["crabs.crabs".to_string(), "localhost".to_string()]);
+	let cert = Certificate::from_params(params);
+
+	let key = cert.serialize_private_key_der();
+	let pkey = PKey::private_key_from_der(&key).unwrap();
+
+	let req = X509Req::from_pem(&cert.serialize_request_pem().as_bytes()).unwrap();
+	req.verify(&pkey).unwrap();
 }


### PR DESCRIPTION
Hey, would you be interested in merging something like this? Seems like a feature that mostly fits, at least, although it maybe widens the scope a bit.

On the other hand, I'm not sure how best to test this for now (although I suppose the openssl library exposes API to actually handle CSRs). So far this is based on just comparing openssl-generated CSRs with the JS ASN.1 thingy you point to in your README.