### PR TITLE
Fixing serialization of distinguished names

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,14 +327,14 @@ impl Certificate {
 	}
 	fn write_name(&self, writer :DERWriter, ca :&Certificate) {
 		writer.write_sequence(|writer| {
-			writer.next().write_set(|writer| {
-				for (ty, content) in ca.params.distinguished_name.entries.iter() {
+			for (ty, content) in ca.params.distinguished_name.entries.iter() {
+				writer.next().write_set(|writer| {
 					writer.next().write_sequence(|writer| {
 						writer.next().write_oid(&ty.to_oid());
 						writer.next().write_utf8_string(content);
 					});
-				}
-			});
+				});
+			}
 		});
 	}
     fn write_request(&self, writer :DERWriter) {


### PR DESCRIPTION
Distinguished names were serialized "the wrong way around". See https://tech.labs.oliverwyman.com/blog/2007/10/30/whats-in-a-distinguished-name/.