### PR TITLE
Expose KeyPair interface

### DIFF
--- a/tests/generic.rs
+++ b/tests/generic.rs
@@ -17,10 +17,6 @@ fn test_key_params_mismatch() {
 			if i == j {
 				continue;
 			}
-			// Issue https://github.com/est31/rcgen/issues/18
-			if (i, j) == (1, 2) || (i, j) == (2, 1) {
-				continue;
-			}
 			let mut wrong_params = util::default_params();
 			if i != 0 {
 				wrong_params.key_pair = Some(KeyPair::generate(kalg_1).unwrap());


### PR DESCRIPTION
Offering an interface to obtain a `KeyPair`'s public key in DER and PEM and access `is_compatible()`

Avoiding code duplication by moving public key serialization into `KeyPair`.

Addresses https://github.com/est31/rcgen/issues/15 and https://github.com/est31/rcgen/issues/18