### PR TITLE
make KeyPair::public_key public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -833,7 +833,7 @@ impl KeyPair {
 			writer.next().write_bitvec_bytes(&pk, pk.len() * 8);
 		})
 	}
-	/// Get the public key from this key pair
+	/// Get the public key of this key pair
 	pub fn public_key(&self) -> &[u8] {
 		match &self.kind {
 			KeyPairKind::Ec(kp) => kp.public_key().as_ref(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -833,7 +833,8 @@ impl KeyPair {
 			writer.next().write_bitvec_bytes(&pk, pk.len() * 8);
 		})
 	}
-	fn public_key(&self) -> &[u8] {
+	/// Get the public key from this key pair
+	pub fn public_key(&self) -> &[u8] {
 		match &self.kind {
 			KeyPairKind::Ec(kp) => kp.public_key().as_ref(),
 			KeyPairKind::Ed(kp) => kp.public_key().as_ref(),


### PR DESCRIPTION
Makes public key easily accessible.

This way the user does not need to serialize to der, then deserialize to get the raw pk.