### PR TITLE
Correct number of nanoseconds per second

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -481,8 +481,8 @@ fn dt_to_generalized(dt :&DateTime<Utc>) -> Result<GeneralizedTime, RcgenError> 
 	// This is needed because the GeneralizedTime serializer would otherwise
 	// output fractional values which RFC 5820 explicitly forbode [1].
 	// [1]: https://tools.ietf.org/html/rfc5280#section-4.1.2.5.2
-	let nanos = if date_time.nanosecond() >= 1_000_000 {
-		1_000_000
+	let nanos = if date_time.nanosecond() >= 1_000_000_000 {
+		1_000_000_000
 	} else {
 		0
 	};


### PR DESCRIPTION
I didn't try to understand what the leap second code is doing, but there are 1e9 nanoseconds per second, and changing this removed the millisecond added to my cert.