### PR TITLE
Don't enable chrono default features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,6 @@ checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
 dependencies = [
  "num-integer",
  "num-traits",
- "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ required-features = ["pem"]
 yasna = { version = "0.3.1", features = ["chrono"] }
 ring = "0.16"
 pem = { version = "0.7", optional = true }
-chrono = "0.4.6"
+chrono = { version = "0.4.6", default-features = false }
 x509-parser = { version = "0.7", optional = true }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/lib.rs"
 [[bin]]
 name = "rcgen"
 path = "src/main.rs"
+required-features = ["pem"]
 
 [dependencies]
 yasna = { version = "0.3.1", features = ["chrono"] }


### PR DESCRIPTION
When a similar [yasna pull request][1] is merged, this will save
a dependency on time 0.1; multiple incompatible versions of time
exist (0.1, 0.2, 0.3 soon) and tend to cause duplicate dependencies.

[1]: https://github.com/qnighy/yasna.rs/pull/49