### PR TITLE
Disable botan dependency and tests on macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,4 +33,6 @@ features = ["x509-parser"]
 [dev-dependencies]
 openssl = "0.10"
 webpki = "0.21"
+
+[target.'cfg(not(target_os = "macos"))'.dependencies]
 botan = { version = "0.7", features = ["vendored"] }

--- a/tests/botan.rs
+++ b/tests/botan.rs
@@ -1,3 +1,5 @@
+#![cfg(not(target_os = "macos"))]
+
 extern crate botan;
 extern crate rcgen;
 


### PR DESCRIPTION
Building Botan on macOS apparently is not supported upstream:

"Currently, systems other than Windows and POSIX (such as VMS,
MacOS 9, OS/390, OS/400, …) are not supported by the build system,
primarily due to lack of access."

https://botan.randombit.net/handbook/building.html