### PR TITLE
Fix mixed signing algorithms & Botan dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,5 +34,5 @@ features = ["x509-parser"]
 openssl = "0.10"
 webpki = "0.21"
 
-[target.'cfg(not(target_os = "macos"))'.dependencies]
+[target.'cfg(not(target_os = "macos"))'.dev-dependencies]
 botan = { version = "0.8", features = ["vendored"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -714,7 +714,7 @@ impl CertificateParams {
 			let serial = self.serial_number.unwrap_or(42);
 			writer.next().write_u64(serial);
 			// Write signature
-			self.alg.write_alg_ident(writer.next());
+			ca.params.alg.write_alg_ident(writer.next());
 			// Write issuer
 			write_distinguished_name(writer.next(), &ca.params.distinguished_name);
 			// Write validity
@@ -869,7 +869,7 @@ impl CertificateParams {
 				writer.next().write_der(&tbs_cert_list_serialized);
 
 				// Write signatureAlgorithm
-				self.alg.write_alg_ident(writer.next());
+				ca.params.alg.write_alg_ident(writer.next());
 
 				// Write signature
 				ca.key_pair.sign(&tbs_cert_list_serialized, writer.next())?;

--- a/tests/openssl.rs
+++ b/tests/openssl.rs
@@ -297,6 +297,25 @@ fn test_openssl_separate_ca() {
 }
 
 #[test]
+fn test_openssl_separate_ca_with_other_signing_alg() {
+	let mut params = util::default_params();
+	params.alg = &rcgen::PKCS_ECDSA_P256_SHA256;
+	params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+	let ca_cert = Certificate::from_params(params).unwrap();
+	let ca_cert_pem = ca_cert.serialize_pem().unwrap();
+
+	let mut params = CertificateParams::new(vec!["crabs.crabs".to_string()]);
+	params.alg = &rcgen::PKCS_ECDSA_P384_SHA384;
+	params.distinguished_name.push(DnType::OrganizationName, "Crab widgits SE");
+	params.distinguished_name.push(DnType::CommonName, "Dev domain");
+	let cert = Certificate::from_params(params).unwrap();
+	let cert_pem = cert.serialize_pem_with_signer(&ca_cert).unwrap();
+	let key = cert.serialize_private_key_der();
+
+	verify_cert_ca(&cert_pem, &key, &ca_cert_pem);
+}
+
+#[test]
 fn test_openssl_separate_ca_name_constraints() {
 	let mut params = util::default_params();
 	params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);


### PR DESCRIPTION
This PR fixes two bugs:

* Certificates which were signed by a CA using a different signing algorithm than the certificate itself were not usable, because the wrong signing algorithm identifier was serialized for the issuer's signature and in the tbsCertificate. This has been fixed, and tests added.
* Botan was always pulled in as a dependency. It is now only pulled in as a dev-dependency only.