### PR TITLE
Small readme example code fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ let subject_alt_names = vec!["hello.world.example".to_string(),
 let cert = generate_simple_self_signed(subject_alt_names).unwrap();
 // The certificate is now valid for localhost and the domain "hello.world.example"
 println!("{}", cert.serialize_pem().unwrap());
-println!("{}", cert.serialize_private_key_pem().unwrap());
+println!("{}", cert.serialize_private_key_pem());
 ```
 
 ## Trying it out with openssl


### PR DESCRIPTION
Hey :)

I just noticed, that there's an unnecessary `.unwrap()` in the example code of your Readme.
Nothing big.
https://docs.rs/rcgen/0.8.9/rcgen/struct.Certificate.html#method.serialize_private_key_pem

Thanks for providing this library!