### PR TITLE
Impl Zeroize for KeyPair and Certificate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -347,6 +347,7 @@ dependencies = [
  "webpki",
  "x509-parser",
  "yasna",
+ "zeroize",
 ]
 
 [[package]]
@@ -604,3 +605,9 @@ checksum = "0de7bff972b4f2a06c85f6d8454b09df153af7e3a4ec2aac81db1b105b684ddb"
 dependencies = [
  "chrono",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81a974bcdd357f0dca4d41677db03436324d45a4c9ed2d0b873a5a360ce41c36"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ ring = "0.16"
 pem = { version = "0.8", optional = true }
 chrono = { version = "0.4.6", default-features = false }
 x509-parser = { version = "0.9", features = ["verify"], optional = true }
+zeroize = { version = "1.2", optional = true }
 
 [features]
 default = ["pem"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1624,6 +1624,35 @@ impl SignatureAlgorithm {
 	}
 }
 
+#[cfg(feature = "zeroize")]
+impl zeroize::Zeroize for KeyPair {
+    fn zeroize(&mut self) {
+        self.serialized_der.zeroize();
+    }
+}
+
+#[cfg(feature = "zeroize")]
+impl zeroize::Zeroize for Certificate {
+    fn zeroize(&mut self) {
+        self.params.zeroize();
+        self.key_pair.zeroize();
+    }
+}
+
+#[cfg(feature = "zeroize")]
+impl zeroize::Zeroize for CertificateSigningRequest {
+    fn zeroize(&mut self) {
+        self.params.zeroize();
+    }
+}
+
+#[cfg(feature = "zeroize")]
+impl zeroize::Zeroize for CertificateParams {
+    fn zeroize(&mut self) {
+        self.key_pair.zeroize();
+    }
+}
+
 #[cfg(test)]
 mod tests {
 	use super::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1626,31 +1626,31 @@ impl SignatureAlgorithm {
 
 #[cfg(feature = "zeroize")]
 impl zeroize::Zeroize for KeyPair {
-    fn zeroize(&mut self) {
-        self.serialized_der.zeroize();
-    }
+	fn zeroize(&mut self) {
+		self.serialized_der.zeroize();
+	}
 }
 
 #[cfg(feature = "zeroize")]
 impl zeroize::Zeroize for Certificate {
-    fn zeroize(&mut self) {
-        self.params.zeroize();
-        self.key_pair.zeroize();
-    }
+	fn zeroize(&mut self) {
+		self.params.zeroize();
+		self.key_pair.zeroize();
+	}
 }
 
 #[cfg(feature = "zeroize")]
 impl zeroize::Zeroize for CertificateSigningRequest {
-    fn zeroize(&mut self) {
-        self.params.zeroize();
-    }
+	fn zeroize(&mut self) {
+		self.params.zeroize();
+	}
 }
 
 #[cfg(feature = "zeroize")]
 impl zeroize::Zeroize for CertificateParams {
-    fn zeroize(&mut self) {
-        self.key_pair.zeroize();
-    }
+	fn zeroize(&mut self) {
+		self.key_pair.zeroize();
+	}
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Here is a proposed implementation for https://github.com/est31/rcgen/issues/47.

This proposition is to have a new optional feature, named `zeroize`. With that option enabled, a dependency to `zeroize` is added and the `Zeroize` trait is implemented for `KeyPair`, and all structures that include such a key pair (`Certificate`, `Certificate`, `CertificateSigningRequest` and `CertificateParams`.  