### PR TITLE
Implement Hash for PublicKey and some more minor improvements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ use rcgen::generate_simple_self_signed;
 # fn main () {
 // Generate a certificate that's valid for "localhost" and "hello.world.example"
 let subject_alt_names = vec!["hello.world.example".to_string(),
-    "localhost".to_string()];
+	"localhost".to_string()];
 
 let cert = generate_simple_self_signed(subject_alt_names).unwrap();
 println!("{}", cert.serialize_pem().unwrap());
@@ -78,7 +78,7 @@ extern crate rcgen;
 use rcgen::generate_simple_self_signed;
 # fn main () {
 let subject_alt_names :&[_] = &["hello.world.example".to_string(),
-    "localhost".to_string()];
+	"localhost".to_string()];
 
 let cert = generate_simple_self_signed(subject_alt_names).unwrap();
 // The certificate is now valid for localhost and the domain "hello.world.example"
@@ -243,6 +243,28 @@ macro_rules! mask {
 }
 
 impl CidrSubnet {
+	/// Obtains the CidrSubnet from the well-known
+	/// addr/prefix notation.
+	/// ```
+	/// # use std::str::FromStr;
+	/// # use rcgen::CidrSubnet;
+	/// // The "192.0.2.0/24" example from
+	/// // https://tools.ietf.org/html/rfc5280#page-42
+	/// let subnet = CidrSubnet::from_str("192.0.2.0/24").unwrap();
+	/// assert_eq!(subnet, CidrSubnet::V4([0xC0, 0x00, 0x02, 0x00], [0xFF, 0xFF, 0xFF, 0x00]));
+	/// ```
+	#[allow(clippy::should_implement_trait, clippy::result_unit_err)]
+	pub fn from_str(s :&str) -> Result<Self, ()> {
+		let mut iter = s.split('/');
+		if let (Some(addr_s), Some(prefix_s)) = (iter.next(), iter.next()) {
+			let addr = IpAddr::from_str(addr_s).map_err(|_| ())?;
+			let prefix = u8::from_str(prefix_s).map_err(|_| ())?;
+			Ok(Self::from_addr_prefix(addr, prefix))
+		} else {
+			Err(())
+		}
+	}
+
 	/// Obtains the CidrSubnet from an ip address
 	/// as well as the specified prefix number.
 	///
@@ -289,31 +311,6 @@ impl CidrSubnet {
 			},
 		}
 		res
-	}
-}
-
-impl FromStr for CidrSubnet {
-	type Err = ();
-
-	/// Obtains the CidrSubnet from the well-known
-	/// addr/prefix notation.
-	/// ```
-	/// # use std::str::FromStr;
-	/// # use rcgen::CidrSubnet;
-	/// // The "192.0.2.0/24" example from
-	/// // https://tools.ietf.org/html/rfc5280#page-42
-	/// let subnet = CidrSubnet::from_str("192.0.2.0/24").unwrap();
-	/// assert_eq!(subnet, CidrSubnet::V4([0xC0, 0x00, 0x02, 0x00], [0xFF, 0xFF, 0xFF, 0x00]));
-	/// ```
-	fn from_str(s :&str) -> Result<Self, Self::Err> {
-		let mut iter = s.split('/');
-		if let (Some(addr_s), Some(prefix_s)) = (iter.next(), iter.next()) {
-			let addr = IpAddr::from_str(addr_s).map_err(|_| ())?;
-			let prefix = u8::from_str(prefix_s).map_err(|_| ())?;
-			Ok(Self::from_addr_prefix(addr, prefix))
-		} else {
-			Err(())
-		}
 	}
 }
 
@@ -598,8 +595,8 @@ pub struct CertificateParams {
 impl Default for CertificateParams {
 	fn default() -> Self {
 		// not_before and not_after set to reasonably long dates
-		let not_before = date_time_ymd(1975, 1, 1);
-		let not_after = date_time_ymd(4096, 1, 1);
+		let not_before = date_time_ymd(1975, 01, 01);
+		let not_after = date_time_ymd(4096, 01, 01);
 		let mut distinguished_name = DistinguishedName::default();
 		distinguished_name.push(DnType::CommonName, "rcgen self signed cert");
 		CertificateParams {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ use rcgen::generate_simple_self_signed;
 # fn main () {
 // Generate a certificate that's valid for "localhost" and "hello.world.example"
 let subject_alt_names = vec!["hello.world.example".to_string(),
-	"localhost".to_string()];
+    "localhost".to_string()];
 
 let cert = generate_simple_self_signed(subject_alt_names).unwrap();
 println!("{}", cert.serialize_pem().unwrap());
@@ -78,7 +78,7 @@ extern crate rcgen;
 use rcgen::generate_simple_self_signed;
 # fn main () {
 let subject_alt_names :&[_] = &["hello.world.example".to_string(),
-	"localhost".to_string()];
+    "localhost".to_string()];
 
 let cert = generate_simple_self_signed(subject_alt_names).unwrap();
 // The certificate is now valid for localhost and the domain "hello.world.example"
@@ -306,7 +306,7 @@ impl FromStr for CidrSubnet {
 	/// assert_eq!(subnet, CidrSubnet::V4([0xC0, 0x00, 0x02, 0x00], [0xFF, 0xFF, 0xFF, 0x00]));
 	/// ```
 	fn from_str(s :&str) -> Result<Self, Self::Err> {
-		let mut iter = s.split("/");
+		let mut iter = s.split('/');
 		if let (Some(addr_s), Some(prefix_s)) = (iter.next(), iter.next()) {
 			let addr = IpAddr::from_str(addr_s).map_err(|_| ())?;
 			let prefix = u8::from_str(prefix_s).map_err(|_| ())?;
@@ -598,8 +598,8 @@ pub struct CertificateParams {
 impl Default for CertificateParams {
 	fn default() -> Self {
 		// not_before and not_after set to reasonably long dates
-		let not_before = date_time_ymd(1975, 01, 01);
-		let not_after = date_time_ymd(4096, 01, 01);
+		let not_before = date_time_ymd(1975, 1, 1);
+		let not_after = date_time_ymd(4096, 1, 1);
 		let mut distinguished_name = DistinguishedName::default();
 		distinguished_name.push(DnType::CommonName, "rcgen self signed cert");
 		CertificateParams {
@@ -921,7 +921,7 @@ impl CertificateParams {
 	pub fn new(subject_alt_names :impl Into<Vec<String>>) -> Self {
 		let subject_alt_names = subject_alt_names.into()
 			.into_iter()
-			.map(|s| SanType::DnsName(s))
+			.map(SanType::DnsName)
 			.collect::<Vec<_>>();
 		CertificateParams {
 			subject_alt_names,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1508,7 +1508,8 @@ impl PublicKeyData for KeyPair {
 	}
 }
 
-trait PublicKeyData {
+#[allow(missing_docs)]
+pub trait PublicKeyData {
 	fn alg(&self) -> &SignatureAlgorithm;
 	fn raw_bytes(&self) -> &[u8];
 	fn serialize_public_key_der(&self, writer :DERWriter) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -885,6 +885,7 @@ impl CertificateParams {
 }
 
 /// Whether the certificate is allowed to sign other certificates
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum IsCa {
 	/// The certificate can only sign itself
 	SelfSignedOnly,
@@ -896,6 +897,7 @@ pub enum IsCa {
 ///
 /// Sets an optional upper limit on the length of the intermediate certificate chain
 /// length allowed for this CA certificate (not including the end entity certificate).
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum BasicConstraints {
 	/// No constraint
 	Unconstrained,
@@ -975,6 +977,7 @@ impl ExtendedKeyUsagePurpose {
 
 /// A custom extension of a certificate, as specified in
 /// [RFC 5280](https://tools.ietf.org/html/rfc5280#section-4.2)
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct CustomExtension {
 	oid :Vec<u64>,
 	critical :bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1229,6 +1229,7 @@ enum SignAlgo {
 	Rsa(),
 }
 
+/// `Hash` is not derived but implemented because of explicit implementation of `PartialEq`
 impl Hash for SignAlgo {
 	fn hash<H: Hasher>(&self, state: &mut H) {
 		format!("{:?}", self).hash(state)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -444,6 +444,12 @@ impl DistinguishedName {
 	}
 }
 
+impl Default for DistinguishedName {
+	fn default() -> Self {
+		Self::new()
+	}
+}
+
 /**
 Iterator over [`DistinguishedName`] entries
 */
@@ -589,7 +595,7 @@ impl Default for CertificateParams {
 		// not_before and not_after set to reasonably long dates
 		let not_before = date_time_ymd(1975, 01, 01);
 		let not_after = date_time_ymd(4096, 01, 01);
-		let mut distinguished_name = DistinguishedName::new();
+		let mut distinguished_name = DistinguishedName::default();
 		distinguished_name.push(DnType::CommonName, "rcgen self signed cert");
 		CertificateParams {
 			alg : &PKCS_ECDSA_P256_SHA256,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1225,6 +1225,7 @@ impl Certificate {
 	}
 }
 
+#[derive(Debug)]
 enum SignAlgo {
 	EcDsa(&'static EcdsaSigningAlgorithm),
 	EdDsa(&'static EdDSAParameters),
@@ -1233,17 +1234,7 @@ enum SignAlgo {
 
 impl Hash for SignAlgo {
 	fn hash<H: Hasher>(&self, state: &mut H) {
-		match self {
-			SignAlgo::EcDsa(_) => {
-				"SignAlgo::EcDsa".hash(state);
-			}
-			SignAlgo::EdDsa(_) => {
-				"SignAlgo::EdDsa".hash(state);
-			}
-			other => {
-				other.hash(state);
-			}
-		}
+		format!("{:?}", self).hash(state)
 	}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -243,26 +243,6 @@ macro_rules! mask {
 }
 
 impl CidrSubnet {
-	/// Obtains the CidrSubnet from the well-known
-	/// addr/prefix notation.
-	/// ```
-	/// # use std::str::FromStr;
-	/// # use rcgen::CidrSubnet;
-	/// // The "192.0.2.0/24" example from
-	/// // https://tools.ietf.org/html/rfc5280#page-42
-	/// let subnet = CidrSubnet::from_str("192.0.2.0/24").unwrap();
-	/// assert_eq!(subnet, CidrSubnet::V4([0xC0, 0x00, 0x02, 0x00], [0xFF, 0xFF, 0xFF, 0x00]));
-	/// ```
-	pub fn from_str(s :&str) -> Result<Self, ()> {
-		let mut iter = s.split("/");
-		if let (Some(addr_s), Some(prefix_s)) = (iter.next(), iter.next()) {
-			let addr = IpAddr::from_str(addr_s).map_err(|_| ())?;
-			let prefix = u8::from_str(prefix_s).map_err(|_| ())?;
-			Ok(Self::from_addr_prefix(addr, prefix))
-		} else {
-			Err(())
-		}
-	}
 	/// Obtains the CidrSubnet from an ip address
 	/// as well as the specified prefix number.
 	///
@@ -309,6 +289,31 @@ impl CidrSubnet {
 			},
 		}
 		res
+	}
+}
+
+impl FromStr for CidrSubnet {
+	type Err = ();
+
+	/// Obtains the CidrSubnet from the well-known
+	/// addr/prefix notation.
+	/// ```
+	/// # use std::str::FromStr;
+	/// # use rcgen::CidrSubnet;
+	/// // The "192.0.2.0/24" example from
+	/// // https://tools.ietf.org/html/rfc5280#page-42
+	/// let subnet = CidrSubnet::from_str("192.0.2.0/24").unwrap();
+	/// assert_eq!(subnet, CidrSubnet::V4([0xC0, 0x00, 0x02, 0x00], [0xFF, 0xFF, 0xFF, 0x00]));
+	/// ```
+	fn from_str(s :&str) -> Result<Self, Self::Err> {
+		let mut iter = s.split("/");
+		if let (Some(addr_s), Some(prefix_s)) = (iter.next(), iter.next()) {
+			let addr = IpAddr::from_str(addr_s).map_err(|_| ())?;
+			let prefix = u8::from_str(prefix_s).map_err(|_| ())?;
+			Ok(Self::from_addr_prefix(addr, prefix))
+		} else {
+			Err(())
+		}
 	}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,7 +254,6 @@ impl CidrSubnet {
 	/// let subnet = CidrSubnet::from_str("192.0.2.0/24").unwrap();
 	/// assert_eq!(subnet, CidrSubnet::V4([0xC0, 0x00, 0x02, 0x00], [0xFF, 0xFF, 0xFF, 0x00]));
 	/// ```
-	#[allow(clippy::should_implement_trait, clippy::result_unit_err)]
 	pub fn from_str(s :&str) -> Result<Self, ()> {
 		let mut iter = s.split('/');
 		if let (Some(addr_s), Some(prefix_s)) = (iter.next(), iter.next()) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1277,7 +1277,7 @@ impl KeyPair {
 	///
 	/// Equivalent to using the [`TryFrom`] implementation.
 	pub fn from_der(der :&[u8]) -> Result<Self, RcgenError> {
-		Ok(der.try_into()?)
+		der.try_into()
 	}
 	/// Parses the key pair from the ASCII PEM format
 	///
@@ -1286,7 +1286,7 @@ impl KeyPair {
 	pub fn from_pem(pem_str :&str) -> Result<Self, RcgenError> {
 		let private_key = pem::parse(pem_str)?;
 		let private_key_der :&[_] = &private_key.contents;
-		Ok(private_key_der.try_into()?)
+		private_key_der.try_into()
 	}
 }
 
@@ -1371,7 +1371,7 @@ impl From<pem::PemError> for RcgenError {
 impl TryFrom<&[u8]> for KeyPair {
 	type Error = RcgenError;
 	fn try_from(pkcs8 :&[u8]) -> Result<KeyPair, RcgenError> {
-		let pkcs8_vec = std::iter::FromIterator::from_iter(pkcs8.iter().cloned());
+		let pkcs8_vec = pkcs8.to_vec();
 
 		let (kind, alg) = if let Ok(edkp) = Ed25519KeyPair::from_pkcs8_maybe_unchecked(pkcs8) {
 			(KeyPairKind::Ed(edkp), &PKCS_ED25519)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::complexity, clippy::style, clippy::pedantic)]
+
 extern crate rcgen;
 
 use rcgen::{Certificate, CertificateParams,

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,8 @@ use std::fs;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
 	let mut params :CertificateParams = Default::default();
-	params.not_before = date_time_ymd(1975, 01, 01);
-	params.not_after = date_time_ymd(4096, 01, 01);
+	params.not_before = date_time_ymd(1975, 1, 1);
+	params.not_after = date_time_ymd(4096, 1, 1);
 	params.distinguished_name = DistinguishedName::new();
 	params.distinguished_name.push(DnType::OrganizationName, "Crab widgits SE");
 	params.distinguished_name.push(DnType::CommonName, "Master Cert");

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,8 @@ use std::fs;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
 	let mut params :CertificateParams = Default::default();
-	params.not_before = date_time_ymd(1975, 1, 1);
-	params.not_after = date_time_ymd(4096, 1, 1);
+	params.not_before = date_time_ymd(1975, 01, 01);
+	params.not_after = date_time_ymd(4096, 01, 01);
 	params.distinguished_name = DistinguishedName::new();
 	params.distinguished_name.push(DnType::OrganizationName, "Crab widgits SE");
 	params.distinguished_name.push(DnType::CommonName, "Master Cert");

--- a/tests/generic.rs
+++ b/tests/generic.rs
@@ -3,6 +3,14 @@ mod util;
 extern crate rcgen;
 
 use rcgen::{RcgenError, KeyPair, Certificate};
+use std::hash::{Hash, Hasher};
+use std::collections::hash_map::DefaultHasher;
+
+fn calculate_hash<T: Hash>(t: &T) -> u64 {
+	let mut s = DefaultHasher::new();
+	t.hash(&mut s);
+	s.finish()
+}
 
 #[test]
 fn test_key_params_mismatch() {
@@ -15,8 +23,14 @@ fn test_key_params_mismatch() {
 	for (i, kalg_1) in available_key_params.iter().enumerate() {
 		for (j, kalg_2) in available_key_params.iter().enumerate() {
 			if i == j {
+				assert_eq!(kalg_1, kalg_2);
+				assert_eq!(calculate_hash(kalg_1), calculate_hash(kalg_2));
 				continue;
 			}
+
+			assert_ne!(kalg_1, kalg_2);
+			assert_ne!(calculate_hash(kalg_1), calculate_hash(kalg_2));
+
 			let mut wrong_params = util::default_params();
 			if i != 0 {
 				wrong_params.key_pair = Some(KeyPair::generate(kalg_1).unwrap());


### PR DESCRIPTION
I want to check for duplicate public keys in CSRs. My idea is a `HashMap<&PublicKey, CertificateSigningRequest>`, but `PublicKey` needs to implement `Hash`.

The problem is `ring` does not implement much. I think my `Hash` impl for `SignAlgo` is sufficient, basically a hash over the raw data of a public key could also do fine. For that reason, I made the `PublicKeyData` trait public, in order to access the raw data via `PublicKeyData::raw_bytes` (but without any documentation yet).

And there are some other non-breaking improvements like `impl Default for DistinguishedName`, `impl FromStr for CidrSubnet` and some other clippy suggestions.