### PR TITLE
Implement Hash for SignatureAlgorithm and PublicKey

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ use std::convert::TryFrom;
 use std::error::Error;
 use std::net::IpAddr;
 use std::str::FromStr;
+use std::hash::{Hash, Hasher};
 
 /// A self signed certificate together with signing keys
 pub struct Certificate {
@@ -465,6 +466,7 @@ impl <'a> Iterator for DistinguishedNameIterator<'a> {
 
 
 /// A public key, extracted from a CSR
+#[derive(Debug, PartialEq, Eq, Hash)]
 pub struct PublicKey {
 	raw: Vec<u8>,
 	alg: &'static SignatureAlgorithm,
@@ -1541,6 +1543,14 @@ impl PartialEq for SignatureAlgorithm {
 }
 
 impl Eq for SignatureAlgorithm {}
+
+/// The `Hash` trait is not derived, but implemented according to impl of the `PartialEq` trait
+impl Hash for SignatureAlgorithm {
+	fn hash<H: Hasher>(&self, state: &mut H) {
+		// see SignatureAlgorithm::eq(), just this field is compared
+		self.oids_sign_alg.hash(state);
+	}
+}
 
 impl SignatureAlgorithm {
 	fn iter() -> std::slice::Iter<'static, &'static SignatureAlgorithm> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::complexity, clippy::style, clippy::pedantic)]
+
 extern crate rcgen;
 
 use rcgen::{Certificate, CertificateParams,

--- a/tests/generic.rs
+++ b/tests/generic.rs
@@ -3,6 +3,14 @@ mod util;
 extern crate rcgen;
 
 use rcgen::{RcgenError, KeyPair, Certificate};
+use std::hash::{Hash, Hasher};
+use std::collections::hash_map::DefaultHasher;
+
+fn generate_hash<T: Hash>(subject: &T) -> u64 {
+	let mut hasher = DefaultHasher::new();
+	subject.hash(&mut hasher);
+	hasher.finish()
+}
 
 #[test]
 fn test_key_params_mismatch() {
@@ -15,8 +23,14 @@ fn test_key_params_mismatch() {
 	for (i, kalg_1) in available_key_params.iter().enumerate() {
 		for (j, kalg_2) in available_key_params.iter().enumerate() {
 			if i == j {
+				assert_eq!(*kalg_1, *kalg_2);
+				assert_eq!(generate_hash(*kalg_1), generate_hash(*kalg_2));
 				continue;
 			}
+
+			assert_ne!(*kalg_1, *kalg_2);
+			assert_ne!(generate_hash(*kalg_1), generate_hash(*kalg_2));
+
 			let mut wrong_params = util::default_params();
 			if i != 0 {
 				wrong_params.key_pair = Some(KeyPair::generate(kalg_1).unwrap());


### PR DESCRIPTION
This is another attempt for implementing Hash for `PublicKey`. I analyzed `SignatureAlgorithm::eq` and the solely compared field is `oids_sign_alg`. To my understanding of how collections rely on a `Hash` implementation, hashing any other field in `SignatureAlgorithm` violates this contract: `k1 == k2 -> hash(k1) == hash(k2)`. It looks kinda odd to me. Simple test cases are included, and all are passing.

Besides, `SignAlgo` can implement `Hash` with `std::ptr::hash()`, but this is apparently no longer needed.