### PR TITLE
Use public key value as a default serial number

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -722,7 +722,10 @@ impl CertificateParams {
 				writer.write_u8(2);
 			});
 			// Write serialNumber
-			let serial = self.serial_number.unwrap_or(42);
+			let serial = self.serial_number.unwrap_or_else(|| {
+				let bytes: [u8; 8] = pub_key.raw_bytes()[0..8].try_into().unwrap();
+				u64::from_le_bytes(bytes)
+			});
 			writer.next().write_u64(serial);
 			// Write signature
 			ca.params.alg.write_alg_ident(writer.next());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -723,7 +723,8 @@ impl CertificateParams {
 			});
 			// Write serialNumber
 			let serial = self.serial_number.unwrap_or_else(|| {
-				let bytes: [u8; 8] = pub_key.raw_bytes()[0..8].try_into().unwrap();
+				let hash = digest::digest(&digest::SHA256, pub_key.raw_bytes());
+				let bytes: [u8; 8] = hash.as_ref()[0..8].try_into().unwrap();
 				u64::from_le_bytes(bytes)
 			});
 			writer.next().write_u64(serial);


### PR DESCRIPTION
Firefox will complain if the same serial number (defaults to 42) is used with different certificate. This happens if you regenerate the certificate. This patch uses value of the public key (first 8 bytes) as the value for the serial number. This way every certificate will get unique serial number. 