### PR TITLE
Switch from `chrono` to `time`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,12 +483,12 @@ name = "rcgen"
 version = "0.8.14"
 dependencies = [
  "botan",
- "chrono",
  "openssl",
  "pem",
  "rand",
  "ring",
  "rsa",
+ "time",
  "webpki",
  "x509-parser",
  "yasna",
@@ -622,6 +622,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99beeb0daeac2bd1e86ac2c21caddecb244b39a093594da1a661ec2060c7aedd"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -776,11 +785,11 @@ dependencies = [
 
 [[package]]
 name = "yasna"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e262a29d0e61ccf2b6190d7050d4b237535fc76ce4c1210d9caa316f71dffa75"
+checksum = "346d34a236c9d3e5f3b9b74563f238f955bbd05fa0b8b4efa53c130c43982f4c"
 dependencies = [
- "chrono",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ path = "src/main.rs"
 required-features = ["pem"]
 
 [dependencies]
-yasna = { version = "0.4", features = ["chrono", "std"] }
+yasna = { version = "0.5", features = ["time", "std"] }
 ring = "0.16"
 pem = { version = "1.0", optional = true }
-chrono = { version = "0.4.6", default-features = false }
+time = { version = "0.3", default-features = false }
 x509-parser = { version = "0.12", features = ["verify"], optional = true }
 zeroize = { version = "1.2", optional = true }
 


### PR DESCRIPTION
⚠️ This currently includes `yasna.rs` as a git dependency, because there's no release with https://github.com/qnighy/yasna.rs/pull/61 yet. I wanted to open the PR anyway to indicate the changes, and perhaps motivate a release for `yasna.rs`.

---

Since https://github.com/qnighy/yasna.rs/pull/61 is merged, I wanted to make the corresponding updates here as well, to hopefully resolve #65.

The changes are very mechanically once again, and again the main limitation is that `time` cannot represent leap seconds. This affects some of the logic and removes a test case.

I've checked the output from `main.rs` and the examples with `openssl x509 -in certs/cert.pem -noout -text` and it's as I'd expect. I've also tried it with a library using QUIC w/ self-signed certs and that also works as expected.