### PR TITLE
Implement TryForm<Vec<u8>> for KeyPair struct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1449,27 +1449,20 @@ impl KeyPair {
 		})
 	}
 
-    fn from_raw(pkcs8: &[u8]) -> Result<(KeyPairKind, &'static SignatureAlgorithm), RcgenError> {
-        Ed25519KeyPair::from_pkcs8_maybe_unchecked(pkcs8)
-            .map(|edkp| (KeyPairKind::Ed(edkp), &PKCS_ED25519))
-            .or_else(|_| {
-                EcdsaKeyPair::from_pkcs8(&signature::ECDSA_P256_SHA256_ASN1_SIGNING, pkcs8)
-                    .map(|eckp| (KeyPairKind::Ec(eckp), &PKCS_ECDSA_P256_SHA256))
-            })
-            .or_else(|_| {
-                EcdsaKeyPair::from_pkcs8(&signature::ECDSA_P384_SHA384_ASN1_SIGNING, pkcs8)
-                    .map(|eckp| (KeyPairKind::Ec(eckp), &PKCS_ECDSA_P384_SHA384))
-            })
-            .or_else(|_| {
-                RsaKeyPair::from_pkcs8(pkcs8).map(|rsakp| {
-                    (
-                        KeyPairKind::Rsa(rsakp, &signature::RSA_PKCS1_SHA256),
-                        &PKCS_RSA_SHA256,
-                    )
-                })
-            })
-            .map_err(|_| RcgenError::CouldNotParseKeyPair)
-    }
+	fn from_raw(pkcs8: &[u8]) -> Result<(KeyPairKind, &'static SignatureAlgorithm), RcgenError> {
+		let (kind, alg) = if let Ok(edkp) = Ed25519KeyPair::from_pkcs8_maybe_unchecked(pkcs8) {
+			(KeyPairKind::Ed(edkp), &PKCS_ED25519)
+		} else if let Ok(eckp) = EcdsaKeyPair::from_pkcs8(&signature::ECDSA_P256_SHA256_ASN1_SIGNING, pkcs8) {
+			(KeyPairKind::Ec(eckp), &PKCS_ECDSA_P256_SHA256)
+		} else if let Ok(eckp) = EcdsaKeyPair::from_pkcs8(&signature::ECDSA_P384_SHA384_ASN1_SIGNING, pkcs8) {
+			(KeyPairKind::Ec(eckp), &PKCS_ECDSA_P384_SHA384)
+		} else if let Ok(rsakp) = RsaKeyPair::from_pkcs8(pkcs8) {
+			(KeyPairKind::Rsa(rsakp, &signature::RSA_PKCS1_SHA256), &PKCS_RSA_SHA256)
+		} else {
+			return Err(RcgenError::CouldNotParseKeyPair);
+		};
+		Ok((kind, alg))
+	}
 }
 
 /// A private key that is not directly accessible, but can be used to sign messages
@@ -1578,27 +1571,29 @@ impl From<pem::PemError> for RcgenError {
 }
 
 impl TryFrom<&[u8]> for KeyPair {
-    type Error = RcgenError;
-    fn try_from(pkcs8: &[u8]) -> Result<KeyPair, RcgenError> {
-        let (kind, alg) = KeyPair::from_raw(pkcs8)?;
-        Ok(KeyPair {
-            kind,
-            alg,
-            serialized_der: pkcs8.to_vec(),
-        })
-    }
+	type Error = RcgenError;
+
+	fn try_from(pkcs8: &[u8]) -> Result<KeyPair, RcgenError> {
+		let (kind, alg) = KeyPair::from_raw(pkcs8)?;
+		Ok(KeyPair {
+			kind,
+			alg,
+			serialized_der: pkcs8.to_vec(),
+		})
+	}
 }
 
 impl TryFrom<Vec<u8>> for KeyPair {
-    type Error = RcgenError;
-    fn try_from(pkcs8: Vec<u8>) -> Result<KeyPair, RcgenError> {
-        let (kind, alg) = KeyPair::from_raw(pkcs8.as_slice())?;
-        Ok(KeyPair {
-            kind,
-            alg,
-            serialized_der: pkcs8,
-        })
-    }
+	type Error = RcgenError;
+
+	fn try_from(pkcs8: Vec<u8>) -> Result<KeyPair, RcgenError> {
+		let (kind, alg) = KeyPair::from_raw(pkcs8.as_slice())?;
+		Ok(KeyPair {
+			kind,
+			alg,
+			serialized_der: pkcs8,
+		})
+	}
 }
 
 impl KeyPair {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1580,7 +1580,7 @@ impl From<pem::PemError> for RcgenError {
 impl TryFrom<&[u8]> for KeyPair {
     type Error = RcgenError;
     fn try_from(pkcs8: &[u8]) -> Result<KeyPair, RcgenError> {
-        let (kind, alg) = KeyPair::from_raw(pkcs8).expect("unable to detect the kind and algorithm");
+        let (kind, alg) = KeyPair::from_raw(pkcs8)?;
         Ok(KeyPair {
             kind,
             alg,
@@ -1592,7 +1592,7 @@ impl TryFrom<&[u8]> for KeyPair {
 impl TryFrom<Vec<u8>> for KeyPair {
     type Error = RcgenError;
     fn try_from(pkcs8: Vec<u8>) -> Result<KeyPair, RcgenError> {
-        let (kind, alg) = KeyPair::from_raw(pkcs8.as_slice()).expect("unable to detect kind and algorithm");
+        let (kind, alg) = KeyPair::from_raw(pkcs8.as_slice())?;
         Ok(KeyPair {
             kind,
             alg,


### PR DESCRIPTION
Hello!

I've implemented TryForm<Vec<u8>> trait for KeyPair to be able to call try_from on a Vec<u8>, avoid to create a new Vec<u8> from a slice of u8.
I also refactor the logic the get the kind and algorithm used for the serialized DER for TryForm trait.