### PR TITLE
chore: use ia5_string for Rfc822Name and DnsName

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -719,7 +719,7 @@ impl CertificateParams {
 					writer.next().write_tagged_implicit(Tag::context(san.tag()), |writer| {
 						match san {
 							SanType::Rfc822Name(name) |
-							SanType::DnsName(name) => writer.write_utf8_string(name),
+							SanType::DnsName(name) => writer.write_ia5_string(name),
 							SanType::IpAddress(IpAddr::V4(addr)) => writer.write_bytes(&addr.octets()),
 							SanType::IpAddress(IpAddr::V6(addr)) => writer.write_bytes(&addr.octets()),
 						}
@@ -1273,7 +1273,7 @@ fn write_general_subtrees(writer :DERWriter, tag :u64, general_subtrees :&[Gener
 					writer.next().write_tagged_implicit(Tag::context(subtree.tag()), |writer| {
 						match subtree {
 							GeneralSubtree::Rfc822Name(name) |
-							GeneralSubtree::DnsName(name) => writer.write_utf8_string(name),
+							GeneralSubtree::DnsName(name) => writer.write_ia5_string(name),
 							GeneralSubtree::DirectoryName(name) => write_distinguished_name(writer, name),
 							GeneralSubtree::IpAddress(subnet) => writer.write_bytes(&subnet.to_bytes()),
 						}


### PR DESCRIPTION
According to [RFC5280](https://datatracker.ietf.org/doc/html/rfc5280#page-38) DNS Name and RFC822 Name are IA5 strings.

```
GeneralName ::= CHOICE {
     otherName                       [0]     OtherName,
     rfc822Name                      [1]     IA5String,
     dNSName                         [2]     IA5String,
     x400Address                     [3]     ORAddress,
     directoryName                   [4]     Name,
     ediPartyName                    [5]     EDIPartyName,
     uniformResourceIdentifier       [6]     IA5String,
     iPAddress                       [7]     OCTET STRING,
     registeredID                    [8]     OBJECT IDENTIFIER }
```

`write_ia5_string` panics if the provided string is not ASCII, perhaps we should add our own `is_ascii` check and return an error instead.