### PR TITLE
Parse an IP address into SanType from a x509 GeneralName.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 certs/
+.idea

--- a/examples/rsa-irc.rs
+++ b/examples/rsa-irc.rs
@@ -31,7 +31,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 	let hash_hex :String = hash.as_ref().iter()
 		.map(|b| format!("{:02x}", b))
 		.collect();
-	println!("sha-512 fingerprint: {hash_tex}");
+	println!("sha-512 fingerprint: {hash_hex}");
 	println!("{pem_serialized}");
 	println!("{}", cert.serialize_private_key_pem());
 	std::fs::create_dir_all("certs/")?;


### PR DESCRIPTION
Support parsing certificates that have an IP address as a subject alternate name. 