### PR TITLE
CertificateParams::new attempt to parse ip address

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1295,7 +1295,12 @@ impl CertificateParams {
 	pub fn new(subject_alt_names :impl Into<Vec<String>>) -> Self {
 		let subject_alt_names = subject_alt_names.into()
 			.into_iter()
-			.map(|s| SanType::DnsName(s))
+			.map(|s| {
+				match s.parse() {
+					Ok(ip) => SanType::IpAddress(ip),
+					Err(_) => SanType::DnsName(s)
+				}
+			})
 			.collect::<Vec<_>>();
 		CertificateParams {
 			subject_alt_names,


### PR DESCRIPTION
supercedes https://github.com/est31/rcgen/pull/113

Guesses what the user meant in some circumstances, email addresses and uri's will still be misunderstood.