### PR TITLE
Use line endings appropriate for current platform

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,33 @@ name: ci
 
 on: [push, pull_request]
 
-jobs:
-  build:
+env:
+  RUSTFLAGS: -D warnings
 
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: stable
+        override: true
+    - run: echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
+    - uses: ilammy/msvc-dev-cmd@v1
+    - run: vcpkg install openssl:x64-windows-static-md
+    - name: Run cargo check --all
+      run: cargo check --all
+    - name: Run the tests
+      run: cargo test --all
+    - name: Run the tests with x509-parser enabled
+      run: cargo test --verbose --features x509-parser
+    - name: Run cargo doc
+      run: cargo doc --all --all-features
+
+
+  build:
     strategy:
       matrix:
         os: [macOS-latest, ubuntu-latest]
@@ -27,20 +51,10 @@ jobs:
         toolchain: ${{ matrix.toolchain }}
         override: true
     - name: Run cargo check --all
-      env:
-        RUSTFLAGS: -D warnings
-      run: |
-        cargo check --all
+      run: cargo check --all
     - name: Run the tests
-      env:
-        RUSTFLAGS: -D warnings
-      run: |
-         cargo test --all
+      run: cargo test --all
     - name: Run the tests with x509-parser enabled
-      env:
-        RUSTFLAGS: -D warnings
-      run: |
-         cargo test --verbose --features x509-parser
+      run: cargo test --verbose --features x509-parser
     - name: Run cargo doc
-      run: |
-        cargo doc --all --all-features
+      run: cargo doc --all --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
         toolchain: stable
         override: true
     - run: echo "VCPKG_ROOT=$env:VCPKG_INSTALLATION_ROOT" | Out-File -FilePath $env:GITHUB_ENV -Append
-    - uses: ilammy/msvc-dev-cmd@v1
     - run: vcpkg install openssl:x64-windows-static-md
     - name: Run cargo check --all
       run: cargo check --all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,9 +37,12 @@ features = ["x509-parser"]
 openssl = "0.10"
 x509-parser = { version = "0.15", features = ["verify"] }
 webpki = { version = "0.22", features = ["std"] }
-botan = { version = "0.10", features = ["vendored"] }
 rand = "0.8"
 rsa = "0.8"
+
+[target.'cfg(not(windows))'.dependencies]
+botan = { version = "0.10", features = ["vendored"] }
+
 
 # This greatly speeds up rsa key generation times
 # (only applies to the dev-dependency because cargo

--- a/tests/botan.rs
+++ b/tests/botan.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "x509-parser")]
+#![cfg(all(feature = "x509-parser", not(windows)))]
 use rcgen::DnValue;
 use rcgen::{BasicConstraints, Certificate, CertificateParams, DnType, IsCa};
 


### PR DESCRIPTION
PR in reference to https://github.com/est31/rcgen/issues/115

Adds platform checking to decide what line endings to use when serializing to PEM.

I tried activating Github Actions for Windows to test correctness for that platform too, but unfortunately it seems the dev-dependency `openssl` does not work: https://github.com/frjonsen/rcgen/actions/runs/4655417259/jobs/8238039795

