### PR TITLE
Updating cert param/key pair comments

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -648,7 +648,6 @@ pub struct CertificateParams {
 	pub extended_key_usages :Vec<ExtendedKeyUsagePurpose>,
 	pub name_constraints :Option<NameConstraints>,
 	pub custom_extensions :Vec<CustomExtension>,
-	/// The certificate's key pair, a new random key pair will be generated if this is `None`
 	pub key_pair :Option<KeyPair>,
 	/// If `true`, the 'Authority Key Identifier' extension will be added to the generated cert
 	pub use_authority_key_identifier_extension :bool,
@@ -1555,7 +1554,8 @@ fn write_general_subtrees(writer :DERWriter, tag :u64, general_subtrees :&[Gener
 }
 
 impl Certificate {
-	/// Generates a new certificate from the given parameters
+	/// Generates a new certificate from the given parameters. If there is no key pair included,
+	/// then a new key pair will be generated and used.
 	pub fn from_params(mut params :CertificateParams) -> Result<Self, RcgenError> {
 		let key_pair = if let Some(key_pair) = params.key_pair.take() {
 			if !key_pair.is_compatible(&params.alg) {


### PR DESCRIPTION
I was a little confused by this comment, since it wasn't clear what code was responsible for generating this key pair. https://github.com/est31/rcgen/blob/14dfa20ed86b78348ce9ddd4d88cc1dc04e702bd/src/lib.rs#L651

I might suggest removing the comment from this field, instead documenting this behavior on `Certificate::from_params`, which appears to be that the original comment was referring to.