### PR TITLE
Turn botan back into a dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ webpki = { version = "0.22", features = ["std"] }
 rand = "0.8"
 rsa = "0.9"
 
-[target.'cfg(not(windows))'.dependencies]
+[target.'cfg(not(windows))'.dev-dependencies]
 botan = { version = "0.10", features = ["vendored"] }
 
 


### PR DESCRIPTION
Fixes a regression from d3ab04a84b78bed81c67d21873581302c787fc25 (#118).

See also c8eb1e689dbd1558738090f2a5e3e06117c66d2e (#43).