### PR TITLE
switch to rustls/webpki, add test coverage for CRL parsing.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -503,8 +503,8 @@ dependencies = [
  "rand",
  "ring",
  "rsa",
+ "rustls-webpki",
  "time",
- "webpki",
  "x509-parser",
  "yasna",
  "zeroize",
@@ -554,6 +554,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
  "nom",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89efed4bd0af2a8de0feb22ba38030244c93db56112b8aa67d27022286852b1c"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -785,16 +795,6 @@ checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ features = ["x509-parser"]
 [dev-dependencies]
 openssl = "0.10"
 x509-parser = { version = "0.15", features = ["verify"] }
-webpki = { version = "0.22", features = ["std"] }
+rustls-webpki = { version = "0.101.0", features = ["std"] }
 rand = "0.8"
 rsa = "0.9"
 

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -81,7 +81,7 @@ pub fn test_crl() -> (CertificateRevocationList, Certificate) {
 	let now = OffsetDateTime::now_utc();
 	let next_week = now + Duration::weeks(1);
 	let revoked_cert = RevokedCertParams{
-		serial_number: SerialNumber::from(9999),
+		serial_number: SerialNumber::from_slice(&[0xC0, 0xFF, 0xEE]),
 		revocation_time: now,
 		reason_code: Some(RevocationReason::KeyCompromise),
 		invalidity_date: None,

--- a/tests/webpki.rs
+++ b/tests/webpki.rs
@@ -65,8 +65,8 @@ fn check_cert_ca<'a, 'b>(cert_der :&[u8], cert :&'a Certificate, ca_der :&[u8],
 
 	// (2/3) Check that the cert is valid for the given DNS name
 	let dns_name = DnsNameRef::try_from_ascii_str("crabs.crabs").unwrap();
-	end_entity_cert.verify_is_valid_for_dns_name(
-		dns_name,
+	end_entity_cert.verify_is_valid_for_subject_name(
+		webpki::SubjectNameRef::from(dns_name)
 	).expect("valid for DNS name");
 
 	// (3/3) Check that a message signed by the cert is valid.


### PR DESCRIPTION
## Description

This is a small follow-up to https://github.com/est31/rcgen/pull/128 now that `rustls/webpki` v0.101.0 has been released. Resolves https://github.com/est31/rcgen/issues/129

### deps: switch to rustls webpki v0.101.0.
The [original webpki](https://github.com/briansmith/webpki) crate is under-maintained, so the [Rustls project](https://github.com/rustls/rustls) has [forked it](https://github.com/rustls/webpki) and invested in maintenance and new features, including [CRL support](https://docs.rs/rustls-webpki/latest/webpki/struct.BorrowedCertRevocationList.html) for client certificate revocation checking.

This commit switches rcgen to use the latest version of the rustls/webpki fork instead of the original upstream webpki project. One small breaking change in the end entity name validation API is fixed in the existing rcgen webpki tests in order to make this switch build/test cleanly.

### tests: update webpki tests to include CRL support.

This commit updates the webpki test suite to include support for parsing and validating a CRL generated by rcgen, as well as a test that checks a revoked EE client cert is rejected when a CRL is provided revoking the cert.