### PR TITLE
lib: add cert and CRL distribution point extension support.

### DIFF
--- a/tests/botan.rs
+++ b/tests/botan.rs
@@ -232,6 +232,7 @@ fn test_botan_crl_parse() {
 		this_update: now,
 		next_update: now + Duration::weeks(1),
 		crl_number: rcgen::SerialNumber::from(1234),
+		issuing_distribution_point: None,
 		revoked_certs: vec![RevokedCertParams{
 			serial_number: ee.get_params().serial_number.clone().unwrap(),
 			revocation_time: now,

--- a/tests/generic.rs
+++ b/tests/generic.rs
@@ -109,7 +109,7 @@ mod test_x509_parser_crl {
 				   crl.get_params().this_update.unix_timestamp());
 		assert_eq!(x509_crl.next_update().unwrap().to_datetime().unix_timestamp(),
 				   crl.get_params().next_update.unix_timestamp());
-		// TODO(XXX): Waiting on https://github.com/rusticata/x509-parser/pull/144
+		// TODO: Waiting on x509-parser 0.15.1 to be released.
 		// let crl_number = BigUint::from_bytes_be(crl.get_params().crl_number.as_ref());
 		// assert_eq!(x509_crl.crl_number().unwrap(), &crl_number);
 
@@ -119,6 +119,13 @@ mod test_x509_parser_crl {
 		assert_eq!(x509_revoked_cert.user_certificate, revoked_cert_serial);
 		let (_, reason_code) = x509_revoked_cert.reason_code().unwrap();
 	 	assert_eq!(reason_code.0, revoked_cert.reason_code.unwrap() as u8);
+
+		// The issuing distribution point extension should be present and marked critical.
+		let issuing_dp_ext = x509_crl.extensions().iter()
+			.find(|ext| ext.oid == x509_parser::oid_registry::OID_X509_EXT_ISSUER_DISTRIBUTION_POINT)
+			.expect("failed to find issuing distribution point extension");
+		assert!(issuing_dp_ext.critical);
+		// TODO: x509-parser does not yet parse the CRL issuing DP extension for further examination.
 
 		// We should be able to verify the CRL signature with the issuer.
 		assert!(x509_crl.verify_signature(&x509_issuer.public_key()).is_ok());

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -1,5 +1,5 @@
 use time::{Duration, OffsetDateTime};
-use rcgen::{BasicConstraints, Certificate, CertificateParams, CertificateRevocationList};
+use rcgen::{BasicConstraints, Certificate, CertificateParams, CertificateRevocationList, CrlDistributionPoint};
 use rcgen::{CertificateRevocationListParams, DnType, IsCa, KeyIdMethod};
 use rcgen::{KeyUsagePurpose, PKCS_ECDSA_P256_SHA256, RevocationReason, RevokedCertParams, SerialNumber};
 
@@ -98,4 +98,20 @@ pub fn test_crl() -> (CertificateRevocationList, Certificate) {
 	let crl = CertificateRevocationList::from_params(crl).unwrap();
 
 	(crl, issuer)
+}
+
+#[allow(unused)] // Used by openssl + x509-parser features.
+pub fn cert_with_crl_dps() -> Vec<u8> {
+	let mut params = default_params();
+	params.crl_distribution_points = vec![
+		CrlDistributionPoint{
+			uris: vec!["http://example.com/crl.der".to_string(), "http://crls.example.com/1234".to_string()],
+		},
+		CrlDistributionPoint{
+			uris: vec!["ldap://example.com/crl.der".to_string()],
+		}
+	];
+
+	let cert = Certificate::from_params(params).unwrap();
+	cert.serialize_der().unwrap()
 }

--- a/tests/util.rs
+++ b/tests/util.rs
@@ -1,5 +1,6 @@
 use time::{Duration, OffsetDateTime};
-use rcgen::{BasicConstraints, Certificate, CertificateParams, CertificateRevocationList, CrlDistributionPoint};
+use rcgen::{BasicConstraints, Certificate, CertificateParams};
+use rcgen::{CertificateRevocationList, CrlDistributionPoint, CrlIssuingDistributionPoint, CrlScope};
 use rcgen::{CertificateRevocationListParams, DnType, IsCa, KeyIdMethod};
 use rcgen::{KeyUsagePurpose, PKCS_ECDSA_P256_SHA256, RevocationReason, RevokedCertParams, SerialNumber};
 
@@ -91,6 +92,10 @@ pub fn test_crl() -> (CertificateRevocationList, Certificate) {
 		this_update: now,
 		next_update: next_week,
 		crl_number: SerialNumber::from(1234),
+		issuing_distribution_point: Some(CrlIssuingDistributionPoint{
+			distribution_point: CrlDistributionPoint { uris: vec!["http://example.com/crl".to_string()] },
+			scope: Some(CrlScope::UserCertsOnly),
+		}),
 		revoked_certs: vec![revoked_cert],
 		alg: &PKCS_ECDSA_P256_SHA256,
 		key_identifier_method: KeyIdMethod::Sha256,

--- a/tests/webpki.rs
+++ b/tests/webpki.rs
@@ -526,3 +526,11 @@ fn test_webpki_crl_revoke() {
 	);
 	assert!(matches!(result, Err(webpki::Error::CertRevoked)));
 }
+
+#[test]
+fn test_webpki_cert_crl_dps() {
+	let der = util::cert_with_crl_dps();
+	webpki::EndEntityCert::try_from(der.as_ref()).expect("failed to parse cert with CRL DPs ext");
+	// Webpki doesn't expose the parsed CRL distribution extension, so we can't interrogate that
+	// it matches the expected form. See `openssl.rs` for more extensive coverage.
+}

--- a/tests/webpki.rs
+++ b/tests/webpki.rs
@@ -503,6 +503,7 @@ fn test_webpki_crl_revoke() {
 		this_update: now,
 		next_update: now + Duration::weeks(1),
 		crl_number: rcgen::SerialNumber::from(1234),
+		issuing_distribution_point: None,
 		revoked_certs: vec![RevokedCertParams{
 			serial_number: ee.get_params().serial_number.clone().unwrap(),
 			revocation_time: now,


### PR DESCRIPTION
## Description

This branch adds support for certificate CRL distribution points extensions, and the corresponding CRL issuing distribution point extension.

Initially I opened this PR with just the former, but the latter is so closely related it felt more appropriate to make one branch with two commits. 

Test coverage is better for the certificate extension compared to the CRL extension, the upstream library support for the latter is quite thin.

I haven't updated the webpki CRL revocation checking tests to demonstrate the new extensions at this time, because it is only available in an alpha release. I can either do this as a follow up once the v/0.102.0 release is cut (likely in O(weeks)) or we could update the dev-dependency to the alpha now and add coverage in this branch. LMK what you would prefer :-)

### lib: add cert CRL distribution points ext. support.
This commit extends rcgen to allow generating certificates that contain an RFC 5280 certificate revocation list (CRL) distribution points extension. This is a useful mechanism for helping ensure CRL coverage when performing revocation checks, and is newly supported by rustls/webpki. See this upstream [webpki issue](https://github.com/rustls/webpki/issues/121) and [RFC 5280 §4.2.1.13](https://www.rfc-editor.org/rfc/rfc5280#section-4.2.1.13) for more background.

Using the new `crl_distribution_points` field of the `CertificateParams` struct it's possible to encode one or more distribution points specifying URI general names where up-to-date CRL information for the certificate can be found.

Similar to existing rcgen CRL generation, the support for this extension is not extensive, but instead tailored towards usage in the web PKI with a RFC 5280 profile.

Notably this means:
* There's no support for specifying the `reasons` flag - RFC 5280 "RECOMMENDS against segmenting CRLs by reason code".
* There's no support for specifying a `cRLIssuer` in the DP - this is specific to indirect CRLs, and neither rcgen's CRL generation code or webpki's parsing/validation support these. 
* There's no support for specifying a `nameRelativeToCrlIssuer` in the DP name instead of a sequence of general names for similar reasons as above: 5280 says: "Conforming CAs SHOULD NOT use nameRelativeToCRLIssuer to specify distribution point names."
* There's no support for specifying general names of type other than URI within a DP name's full name. Other name types either don't make sense in the context of this extension, or are rarely useful in practice (e.g. directory name).

Test coverage is mixed based on the support of the relevant third party libraries. OpenSSL (openssl-rs) and x509-parser both parse this extension well, and so the `openssl.rs` and `generic.rs` test coverage is the most extensive. Webpki (v/0.102.0-alpha.0) recognizes this extension for use during revocation checking, but doesn't expose it externally so a simple parse test is added. Botan's rust bindings do not recognize the extension or offer a way to pull out arbitrary extensions, so no test coverage is added there.


### lib: add CRL issuing distribution point ext. support.
This commit extends rcgen to allow generating certificate revocation lists (CRLs) that contain an RFC 5280 CRL issuing distribution point extension. This is a useful mechanism for helping ensure CRL coverage when performing revocation checks, and is newly supported by rustls/webpki. See this upstream [webpki issue](https://github.com/rustls/webpki/issues/121) and [RFC 5280 §5.2.5](https://www.rfc-editor.org/rfc/rfc5280#section-5.2.5) for more background.

Using the new optional `issuing_distribution_point` field of the `CertificateRevocationListParams` struct it's possible to encode a
issuing distribution point specifying URI general names where up-to-date CRL information for the CRL can be found.

Similar to existing rcgen CRL generation, the support for this extension is not extensive, but instead tailored towards usage in the web PKI with a RFC 5280 profile.

Notably this means:
* There's no support for specifying the `indirectCRL` bool - neither rcgen's existing CRL generation code or webpki's parsing/validation supports these.
* There's no support for specifying the `onlySomeReasons` field - RFC 5280 "RECOMMENDS against segmenting CRLs by reason code". 
* There's no support for specifying a `onlyContainsAttributeCerts` bool - RFC 5280 says "Conforming CRLs issuers MUST set the onlyContainsAttributeCerts boolean to FALSE." and the DER encoding of 'false' requires eliding the value.
* There's no support for specifying a 'nameRelativeToCrlIssuer' in the  DP name instead of a sequence of general names for similar reasons as  above: 5280 says: "Conforming CAs SHOULD NOT use nameRelativeToCRLIssuer to specify distribution point names."
* There's no support for specifying general names of type other than URI  within a DP name's full name. Other name types either don't make sense in the context of this extension, or are rarely useful in practice (e.g. directory name).

Compared to test coverage of the certificate CRL distribution points extension this commit can't offer too much. OpenSSL (openssl-rs) doesn't expose arbitrary CRL extensions, or the issuing distribution point. The `x509-parser` crate can pull out the extension, but doesn't decompose the value (I may attempt to land code for this upstream in the future, stay tuned). Webpki (v/0.102.0-alpha.0) recognizes this extension for use during revocation checking, but doesn't expose it externally. Botan's rust bindings do not recognize the extension or offer a way to pull out arbitrary extensions, so no test coverage is added there.